### PR TITLE
Rewrite elect-record using mongodb native api

### DIFF
--- a/lib/jobs/elect-record/index.js
+++ b/lib/jobs/elect-record/index.js
@@ -41,27 +41,25 @@ async function electRecord({data: {recordId}}) {
 
   debug(`Electing new record revision for ${recordId}: ${recordHash}`)
 
-  await Promise.all([
-    RecordRevision.collection.updateMany({
-      recordId,
-      recordHash: {
-        $ne: recordHash
-      }
-    }, {
-      $set: {
-        featured: false
-      }
-    }),
+  // Unfeature previously featured revision
+  await RecordRevision.collection.updateOne({
+    recordId,
+    featured: true
+  }, {
+    $set: {
+      featured: false
+    }
+  })
 
-    RecordRevision.collection.updateOne({
-      recordId,
-      recordHash
-    }, {
-      $set: {
-        featured: true
-      }
-    })
-  ])
+  // Feature new revision
+  await RecordRevision.collection.updateOne({
+    recordId,
+    recordHash
+  }, {
+    $set: {
+      featured: true
+    }
+  })
 
   await Record.triggerUpdated(recordId, 'new featured revision')
 }

--- a/lib/jobs/elect-record/index.js
+++ b/lib/jobs/elect-record/index.js
@@ -1,37 +1,66 @@
-'use strict'
-
 const mongoose = require('mongoose')
+const debug = require('debug')('geoplatform:jobs:elect-record')
 
 const CatalogRecord = mongoose.model('CatalogRecord')
 const RecordRevision = mongoose.model('RecordRevision')
 const Record = mongoose.model('ConsolidatedRecord')
 
 async function electRecord({data: {recordId}}) {
-  const catalogRecords = await CatalogRecord
-    .find({recordId})
-    .sort('-revisionDate -touchedAt')
-    .lean()
-    .exec()
+  const catalogRecord = await CatalogRecord.collection.findOne({
+    recordId
+  }, {
+    sort: [
+      ['revisionDate', -1],
+      ['touchedAt', -1]
+    ],
+    projection: {
+      recordHash: 1
+    }
+  })
 
-  if (catalogRecords.length === 0) {
+  if (!catalogRecord) {
+    // Catalog record doesn’t exist
     return
   }
 
-  const {recordHash} = catalogRecords[0]
+  const {recordHash} = catalogRecord
 
-  const electedRecord = await RecordRevision
-    .find({recordId, recordHash})
-    .select('featured')
-    .exec()
+  const electedRecord = await RecordRevision.collection.findOne({
+    recordId,
+    recordHash
+  }, {
+    projection: {
+      featured: 1
+    }
+  })
 
-  // RecordRevision is already featured
-  if (electedRecord.featured) {
+  if (!electedRecord || electedRecord.featured) {
+    // Record revision doesn’t exist or is already featured
     return
   }
+
+  debug(`Electing new record revision for ${recordId}: ${recordHash}`)
 
   await Promise.all([
-    RecordRevision.updateOne({recordId, recordHash}, {$set: {featured: true}}).exec(),
-    RecordRevision.updateMany({recordId, recordHash: {$ne: recordHash}}, {$set: {featured: false}}).exec()
+    RecordRevision.collection.updateMany({
+      recordId,
+      recordHash: {
+        $ne: recordHash
+      }
+    }, {
+      $set: {
+        featured: false
+      }
+    }),
+
+    RecordRevision.collection.updateOne({
+      recordId,
+      recordHash
+    }, {
+      $set: {
+        featured: true
+      }
+    })
   ])
 
   await Record.triggerUpdated(recordId, 'new featured revision')

--- a/lib/models/RecordRevision.js
+++ b/lib/models/RecordRevision.js
@@ -5,29 +5,49 @@ const mongoose = require('mongoose')
 const {Schema} = require('mongoose')
 const {enqueue} = require('delayed-jobs')
 
-const Mixed = Schema.Types.Mixed
+const {Mixed} = Schema.Types
 
 const collectionName = 'record_revisions'
 
 const schema = new Schema({
 
   /* Identification */
-  recordId:     {type: String, required: true},
-  recordHash:   {type: String, required: true},
+  recordId: {
+    type: String,
+    required: true
+  },
+  recordHash: {
+    type: String,
+    required: true
+  },
 
   /* Attributes */
-  revisionDate: {type: Date},
+  revisionDate: {
+    type: Date
+  },
 
   /* Featuring */
-  featured: {type: Boolean},
+  featured: {
+    type: Boolean
+  },
 
   /* Content */
-  recordType:    {type: String, enum: ['MD_Metadata', 'Record', 'FC_FeatureCatalog']},
-  content:      {type: Mixed, required: true},
+  recordType: {
+    type: String,
+    enum: ['MD_Metadata', 'Record', 'FC_FeatureCatalog']
+  },
+  content: {
+    type: Mixed,
+    required: true
+  },
 
   /* Dates */
-  createdAt:    {type: Date},
-  touchedAt:    {type: Date}
+  createdAt: {
+    type: Date
+  },
+  touchedAt: {
+    type: Date
+  }
 })
 
 /*
@@ -37,13 +57,12 @@ const schema = new Schema({
 schema.index({recordId: 1, recordHash: 1}, {unique: true})
 
 // Ensure each recordId is featured once
-schema.index(
-  {recordId: 1},
-  {
-    unique: true,
-    partialFilterExpression: {featured: true}
-  }
-)
+schema.index({
+  recordId: 1
+}, {
+  unique: true,
+  partialFilterExpression: {featured: true}
+})
 
 /*
 ** Statics


### PR DESCRIPTION
The previous code would never skip changing the featured record, because mongoose’s `Model.find().exec()` would return `Promise<Array>`, and `[].featured` would always be `undefined`.

Also, only find one `CatalogRecord` as we only need the latest one.