### PR TITLE
Add elect-records maintenance job and run others in the background

### DIFF
--- a/lib/api/controllers/maintenance.js
+++ b/lib/api/controllers/maintenance.js
@@ -30,7 +30,10 @@ const consolidateRecords = am(async (req, res) => {
 
   const {count} = await ConsolidatedRecord.consolidateMany({limit})
 
-  res.status(202).send({task: 'consolidate-records', count})
+  res.status(202).send({
+    task: 'consolidate-records',
+    count
+  })
 })
 
 const computeCatalogsMetrics = am(async (req, res) => {
@@ -40,16 +43,16 @@ const computeCatalogsMetrics = am(async (req, res) => {
     }
   }).toArray()
 
-  await Promise.all(
-    catalogs.map(({_id}) => {
-      return enqueue('compute-catalog-metrics', {
-        catalogId: _id
-      })
+  for (const {_id} of catalogs) {
+    enqueue('compute-catalog-metrics', {
+      catalogId: _id,
+      force: true
     })
-  )
+  }
 
-  res.send({
-    task: 'compute-catalogs-metrics', count: catalogs.length
+  res.status(202).send({
+    task: 'compute-catalogs-metrics',
+    count: catalogs.length
   })
 })
 

--- a/lib/api/controllers/maintenance.js
+++ b/lib/api/controllers/maintenance.js
@@ -7,6 +7,23 @@ const am = require('../middlewares/async')
 const ConsolidatedRecord = mongoose.model('ConsolidatedRecord')
 const Catalog = mongoose.model('Catalog')
 
+const electRecords = am(async (req, res) => {
+  const records = await ConsolidatedRecord.collection.find({}, {
+    projection: {
+      recordId: 1
+    }
+  }).toArray()
+
+  for (const {recordId} of records) {
+    enqueue('elect-record', {recordId})
+  }
+
+  res.status(202).send({
+    task: 'elect-record',
+    count: records.length
+  })
+})
+
 const consolidateRecords = am(async (req, res) => {
   const reqLimit = parseInt(req.query.limit, 10)
   const limit = isNumber(reqLimit) && reqLimit > 0 ? reqLimit : 100
@@ -36,4 +53,4 @@ const computeCatalogsMetrics = am(async (req, res) => {
   })
 })
 
-module.exports = {consolidateRecords, computeCatalogsMetrics}
+module.exports = {electRecords, consolidateRecords, computeCatalogsMetrics}

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -3,7 +3,6 @@ const cors = require('cors')
 
 const sentry = require('../utils/sentry')
 
-const registerMaintenanceRoutes = require('./routes/maintenance')
 const registerPublicationsRoutes = require('./routes/publications')
 const registerRecordsRoutes = require('./routes/records')
 const registerServicesRoutes = require('./routes/services')
@@ -13,11 +12,11 @@ const router = new Router()
 router.use(cors({origin: true}))
 router.use(json())
 
-registerMaintenanceRoutes(router)
 registerPublicationsRoutes(router)
 registerRecordsRoutes(router)
 registerServicesRoutes(router)
 
+router.use('/maintenance', require('./routes/maintenance'))
 router.use('/catalogs', require('./routes/catalogs'))
 router.use('/links', require('./routes/links'))
 

--- a/lib/api/routes/maintenance.js
+++ b/lib/api/routes/maintenance.js
@@ -1,16 +1,14 @@
-'use strict'
-
 const {Router} = require('express')
 
-const {consolidateRecords, computeCatalogsMetrics} = require('../controllers/maintenance')
 const {isMaintenance} = require('../middlewares/auth')
+const {electRecords, consolidateRecords, computeCatalogsMetrics} = require('../controllers/maintenance')
 
-module.exports = function (app) {
-  const router = new Router()
+const router = new Router()
 
-  /* Routes */
-  router.post('/consolidate-records', consolidateRecords)
-  router.post('/compute-catalogs-metrics', computeCatalogsMetrics)
+router.use(isMaintenance)
 
-  app.use('/maintenance', isMaintenance, router)
-}
+router.post('/elect-records', electRecords)
+router.post('/consolidate-records', consolidateRecords)
+router.post('/compute-catalogs-metrics', computeCatalogsMetrics)
+
+module.exports = router

--- a/lib/jobs/compute-catalog-metrics/index.js
+++ b/lib/jobs/compute-catalog-metrics/index.js
@@ -16,7 +16,7 @@ function countBy(result, property) {
   }
 }
 
-async function computeCatalogMetrics({data: {catalogId}}) {
+async function computeCatalogMetrics({data: {catalogId, force = false}}) {
   const catalog = await Catalog.collection.findOne({
     _id: new mongoose.mongo.ObjectId(catalogId)
   }, {
@@ -31,7 +31,7 @@ async function computeCatalogMetrics({data: {catalogId}}) {
     return
   }
 
-  if (catalog.metrics && moment().diff(catalog.metrics.updatedAt, 'hours') < 2) {
+  if (!force && catalog.metrics && moment().diff(catalog.metrics.updatedAt, 'hours') < 2) {
     debug(`Metrics were computed less than 2 hours ago for catalog ${catalog.name}`)
     return
   }

--- a/lib/jobs/harvest-csw/index.js
+++ b/lib/jobs/harvest-csw/index.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const {inspect} = require('util')
 const each = require('stream-each')
 const mongoose = require('mongoose')
@@ -36,10 +34,10 @@ class CswHarvestJob extends ServiceSyncJob {
     const ignore = reason => {
       this.ignored++
 
-      if (!(reason in this.ignoreStats)) {
-        this.ignoreStats[reason] = 1
-      } else {
+      if (reason in this.ignoreStats) {
         this.ignoreStats[reason]++
+      } else {
+        this.ignoreStats[reason] = 1
       }
 
       if (reason === 'Identifier too short') {
@@ -108,7 +106,7 @@ class CswHarvestJob extends ServiceSyncJob {
 
     this.ignoreStats = {}
 
-    const location = this.service.location
+    const {location} = this.service
     const client = csw(location)
 
     const schema = location.includes('grandlyon') || location.includes('adour-garonne') ?
@@ -148,6 +146,6 @@ class CswHarvestJob extends ServiceSyncJob {
   }
 }
 
-exports.handler = function harvest({data, log, progress}) {
+exports.handler = ({data, log, progress}) => {
   return (new CswHarvestJob({data, log, progress}, {failsAfter: 600})).exec()
 }

--- a/lib/jobs/harvest-csw/index.js
+++ b/lib/jobs/harvest-csw/index.js
@@ -138,7 +138,9 @@ class CswHarvestJob extends ServiceSyncJob {
 
         // Compute catalog statistics
         // Catalogs and services share the same _id, so we’re passing service._id here.
-        enqueue('compute-catalog-metrics', {catalogId: this.service._id})
+        enqueue('compute-catalog-metrics', {
+          catalogId: this.service._id
+        })
 
         this.success(this.returned)
       }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
   "xo": {
     "semicolon": false,
     "space": 2,
+    "rules": {
+      "camelcase": "warn"
+    },
     "overrides": [
       {
         "files": "__tests__/**/*.js",


### PR DESCRIPTION
Also add `force` parameter to compute-catalog-metrics and enable it for the maintenance job.

Fix some lint errors.

The `elect-records` ensures that the featured record is always the right one. It should not happen, but I have some old records that do not feature the right revision.