### PR TITLE
Ignore "other" resource types in publication

### DIFF
--- a/plugins/publish-to-udata/mapping.js
+++ b/plugins/publish-to-udata/mapping.js
@@ -108,7 +108,9 @@ function extractDownloadResources(resource) {
       }
 
       default:
-        if (!download.archive) {
+        // Do not publish "other" resourceTypes for now
+        // The resource type mappings are defined in lib/jobs/consolidate-records/links.js
+        if (!download.archive && download.resourceType !== 'other') {
           resources.push({
             url: download.url,
             title: download.name,


### PR DESCRIPTION
Only the following resource types will be published for now.

```js
const resourceTypes = {
  vector: [
    'shp',
    'mif',
    'tab',
    'geojson',
    'kml',
    'gpx'
  ],
  raster: [
    'tiff',
    'ecw',
    'jpeg2000'
  ],
  table: [
    'csv',
    'xls'
  ],
  data: [
    'grib2',
    'owl',
    'rdf',
    'dbf'
  ]
}
```