### PR TITLE
Fix publication api routes

### DIFF
--- a/lib/api/controllers/publications.js
+++ b/lib/api/controllers/publications.js
@@ -1,78 +1,106 @@
-'use strict'
-
 const mongoose = require('mongoose')
-const {pick} = require('lodash')
 
 const {Http404} = require('../errors')
 const am = require('../middlewares/async')
 
 const Publication = mongoose.model('Publication')
 
-/* Params */
-
-exports.publication = async (req, res, next, publicationTarget) => {
-  const {recordId} = req.params
-
-  try {
-    const publication = await Publication.findOne({recordId, target: publicationTarget}).exec()
-    req.publication = publication
-
-    next()
-  } catch (error) {
-    next(error)
-  }
-}
-
-/* Actions */
-
 exports.publishOrUpdate = am(async (req, res) => {
-  const {recordId, publicationTarget} = req.params
+  const {recordId} = req.params
   const {remoteId, remoteUrl} = req.body
 
-  if (!req.publication) {
-    req.publication = new Publication({recordId, target: publicationTarget})
+  const publication = await Publication.findOne({
+    recordId,
+    target: 'dgv'
+  }).exec()
+
+  if (!publication) {
+    req.publication = new Publication({
+      recordId,
+      target: 'dgv'
+    })
   }
 
-  const publication = await req.publication.set({remoteId, remoteUrl}).save()
+  await publication.set({
+    remoteId,
+    remoteUrl
+  }).save()
 
   res.send(publication)
 })
 
-exports.show = (req, res) => {
-  const FIELDS = ['updatedAt', 'createdAt', 'remoteId', 'remoteUrl']
+exports.show = am(async (req, res) => {
+  const {recordId} = req.params
 
-  if (!req.publication) {
+  const publication = await Publication.collection.findOne({
+    recordId,
+    target: 'dgv'
+  }, {
+    projection: {
+      _id: 0,
+      updatedAt: 1,
+      createdAt: 1,
+      remoteId: 1,
+      remoteUrl: 1
+    }
+  })
+
+  if (!publication) {
     throw new Http404()
   }
 
-  res.send(pick(req.publication, ...FIELDS))
-}
+  res.send(publication)
+})
 
 exports.list = am(async (req, res) => {
   const {recordId} = req.params
-  const FIELDS = ['updatedAt', 'createdAt', 'remoteId', 'remoteUrl', 'target']
 
-  const publications = await Publication.find({recordId}).exec()
+  const publications = await Publication.collection.find({
+    recordId
+  }, {
+    projection: {
+      _id: 0,
+      updatedAt: 1,
+      createdAt: 1,
+      remoteId: 1,
+      remoteUrl: 1,
+      target: 1
+    }
+  }).toArray()
 
-  res.send(publications.map(p => pick(p, ...FIELDS)))
+  res.send(publications)
 })
 
 exports.listAll = am(async (req, res) => {
-  const publications = await Publication
-    .find({target: req.params.target})
-    .select({__v: 0, _id: 0, target: 0})
-    .lean()
-    .exec()
+  const publications = await Publication.collection.find({
+    target: 'dgv'
+  }, {
+    projection: {
+      _id: 0,
+      updatedAt: 1,
+      createdAt: 1,
+      recordId: 1,
+      remoteId: 1,
+      remoteUrl: 1
+    }
+  }).toArray()
 
   res.send(publications)
 })
 
 exports.unpublish = am(async (req, res) => {
-  if (!req.publication) {
+  const {recordId} = req.params
+
+  const publication = await Publication.findOne({
+    recordId,
+    target: 'dgv'
+  }).exec()
+
+  if (!publication) {
     throw new Http404()
   }
 
-  await req.publication.delete()
+  await publication.delete()
 
   res.status(204).send()
 })

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -3,7 +3,6 @@ const cors = require('cors')
 
 const sentry = require('../utils/sentry')
 
-const registerPublicationsRoutes = require('./routes/publications')
 const registerRecordsRoutes = require('./routes/records')
 const registerServicesRoutes = require('./routes/services')
 
@@ -12,7 +11,8 @@ const router = new Router()
 router.use(cors({origin: true}))
 router.use(json())
 
-registerPublicationsRoutes(router)
+router.use(require('./routes/publications'))
+
 registerRecordsRoutes(router)
 registerServicesRoutes(router)
 

--- a/lib/api/routes/publications.js
+++ b/lib/api/routes/publications.js
@@ -1,16 +1,17 @@
-const publications = require('../controllers/publications')
+const {Router} = require('express')
 
-module.exports = function (app) {
-  app.param('publicationTarget', publications.publication)
+const {listAll, list, show, publishOrUpdate, unpublish} = require('../controllers/publications')
 
-  app.route('/publications/:target')
-    .get(publications.listAll)
+const router = new Router()
 
-  app.route('/records/:recordId/publications')
-    .get(publications.list)
+router.get('/publications/dgv', listAll)
 
-  app.route('/records/:recordId/publications/:publicationTarget')
-    .get(publications.show)
-    .put(publications.publishOrUpdate)
-    .delete(publications.unpublish)
-}
+router.get('/records/:recordId/publications', list)
+
+router.route('/records/:recordId/publications/dgv')
+  .get(show)
+  .put(publishOrUpdate)
+  .delete(unpublish)
+
+module.exports = router
+


### PR DESCRIPTION
Fix 404 when published record doesn’t exist anymore.

Also get rid of `publicationTarget` and hardcode `dgv` for now.