### PR TITLE
Fix mif files download with ogr2ogr

### DIFF
--- a/lib/api/routes/links.js
+++ b/lib/api/routes/links.js
@@ -24,6 +24,7 @@ router.get(
     const downloader = ogr2ogr.downloadDataset(download.url, {
       type: 'url',
       name: download.name,
+      archive: download.archive,
       format: download.type
     })
 

--- a/lib/extract/ogr2ogr.js
+++ b/lib/extract/ogr2ogr.js
@@ -14,7 +14,7 @@ function getSource(method, source, type) {
       return `WFS:${source}`
 
     case 'url':
-      return got.stream(source)
+      return got.stream(source).pause()
 
     default:
       return source
@@ -31,6 +31,16 @@ function getProjection(projection) {
 
     default:
       return null
+  }
+}
+
+function getInputFormat(format) {
+  switch (format) {
+    case 'mif':
+      return 'MapInfo File'
+
+    default:
+      return format
   }
 }
 
@@ -111,15 +121,34 @@ function downloadDataset(input, opts) {
     }
 
     const source = getSource(req.method, input, opts.type)
+    const inputFormat = getInputFormat(opts.format)
     const options = getOptions(opts)
 
-    ogr2ogr(source, opts.format)
+    const ogr = ogr2ogr(source, inputFormat)
       .timeout(defaultTimeout)
       .project(projection)
       .format(format)
       .options(options)
-      .stream()
-      .pipe(res)
+
+    // Disable unarchiving if the input is not an archive
+    if (opts.archive === false && ogr._inDriver.output === 'zip') {
+      ogr._inDriver.output = opts.format
+    }
+
+    return new Promise((resolve, reject) => {
+      ogr
+        .stream()
+        .on('error', error => {
+          reject(error)
+        })
+        .on('end', () => {
+          resolve()
+        })
+        .pipe(res)
+        .on('error', error => {
+          reject(error)
+        })
+    })
   })
 }
 

--- a/lib/utils/sentry.js
+++ b/lib/utils/sentry.js
@@ -18,9 +18,9 @@ if (SENTRY_DSN) {
     },
 
     errorHandler() {
-      return (err, req, res, next) => {
-        this.captureException(err)
-        next()
+      return (error, req, res, next) => {
+        this.captureException(error)
+        next(error)
       }
     }
   }


### PR DESCRIPTION
`MapInfo files` default to a `zip` file, so we need to disable unarchiving if we’re dealing with a single `.mif` file:

```js
if (opts.archive === false && ogr._inDriver.output === 'zip') {
  ogr._inDriver.output = opts.format
}
```

There is no cleaner way to fix that. :(