### PR TITLE
Use own docker-gdal base image

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,5 @@
 # 1/2 Create build image
-FROM node:10-alpine AS build
+FROM geodatagouv/node-gdal:10 AS build
 
 RUN mkdir -p /opt/geoplatform-web
 WORKDIR /opt/geoplatform-web
@@ -8,16 +8,8 @@ COPY package.json yarn.lock ./
 RUN yarn --production --frozen-lockfile
 
 # 2/2 Create production image
-FROM node:10-alpine
+FROM geodatagouv/node-gdal:10
 ARG SOURCE_COMMIT=unknown
-
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-      libcrypto1.1 \
-      curl=7.63.0-r0  \
-      && \
-    apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-      proj4-dev=5.0.1-r1 \
-      gdal=2.4.0-r0
 
 RUN mkdir -p /opt/geoplatform-web
 WORKDIR /opt/geoplatform-web


### PR DESCRIPTION
ogr segfaults when fetching WFS urls with gdal on alpine.