### PR TITLE
Skip ogr2ogr failures

### DIFF
--- a/lib/extract/ogr2ogr.js
+++ b/lib/extract/ogr2ogr.js
@@ -126,6 +126,7 @@ function downloadDataset(input, opts) {
 
     const ogr = ogr2ogr(source, inputFormat)
       .timeout(defaultTimeout)
+      .skipfailures()
       .project(projection)
       .format(format)
       .options(options)


### PR DESCRIPTION
Prevent useless sentry errors.