### PR TITLE
Remove _featureTypes property

### DIFF
--- a/__tests__/plugins/publish-to-udata/__fixtures__/mapping/da40697278592843273355722d08ca2db742a902.json
+++ b/__tests__/plugins/publish-to-udata/__fixtures__/mapping/da40697278592843273355722d08ca2db742a902.json
@@ -7,7 +7,6 @@
   "organizations": [
       "DDT Val-d'Oise"
   ],
-  "_featureTypes": [],
   "_links": [
       {
           "name": "Vue XML des métadonnées",

--- a/lib/models/ConsolidatedRecord.js
+++ b/lib/models/ConsolidatedRecord.js
@@ -62,11 +62,6 @@ const schema = new Schema({
     index: true
   },
 
-  _featureTypes: {
-    type: [Mixed],
-    select: false
-  },
-
   _links: {
     type: [Mixed],
     select: false


### PR DESCRIPTION
It is not used anymore and can free up some space in the `consolidated_records` collection.