### PR TITLE
Update CatalogRecord elect-record index

### DIFF
--- a/lib/models/CatalogRecord.js
+++ b/lib/models/CatalogRecord.js
@@ -42,8 +42,8 @@ const schema = new mongoose.Schema({
 })
 
 /* Indexes */
-schema.index({recordId: 1})
 schema.index({catalog: 1, recordId: 1}, {unique: true})
+schema.index({recordId: 1, revisioDate: -1, touchedAt: -1})
 
 /* Statics */
 schema.statics = {


### PR DESCRIPTION
`elect-record` needs this index in order to prevent big COLLSCANs.