### PR TITLE
Consider mif/mid files as raw data

### DIFF
--- a/lib/jobs/consolidate-record/links.js
+++ b/lib/jobs/consolidate-record/links.js
@@ -8,7 +8,6 @@ const {proxyLink, getLink, getLinkByLocation, getLastCheck} = require('../../ser
 const resourceTypes = {
   vector: [
     'shp',
-    'mif',
     'tab',
     'geojson',
     'kml',
@@ -27,7 +26,8 @@ const resourceTypes = {
     'grib2',
     'owl',
     'rdf',
-    'dbf'
+    'dbf',
+    'mif'
   ]
 }
 


### PR DESCRIPTION
They’re not supported by `ogr2ogr` (and usually fail), so let’s not transcode them.